### PR TITLE
Updated dependencies and targets

### DIFF
--- a/RssFeedParser.Test/FeedParserTest.cs
+++ b/RssFeedParser.Test/FeedParserTest.cs
@@ -40,7 +40,6 @@ namespace RssFeedParser.Test
         [Fact]
         public async void TestTweakersFeed()
         {
-
             var contents = File.ReadAllText(Path.Combine("ExampleFeeds", "Tweakers1.xml"));
 
             XDocument doc = XDocument.Parse(contents);
@@ -48,8 +47,7 @@ namespace RssFeedParser.Test
             var rssFeedParser = new FeedParser();
             RssFeed feed = await rssFeedParser.ParseFeed(doc);
 
-            Assert.Equal(feed.Articles.Count, 40);         
-
+            Assert.Equal(40, feed.Articles.Count);         
         }
 
         [Fact]
@@ -63,7 +61,7 @@ namespace RssFeedParser.Test
             var rssFeedParser = new FeedParser();
             RssFeed feed = await rssFeedParser.ParseFeed(doc);
 
-            Assert.Equal(feed.Articles.Count, 25);
+            Assert.Equal(25, feed.Articles.Count);
 
             foreach (var article in feed.Articles)
             {
@@ -86,14 +84,10 @@ namespace RssFeedParser.Test
             var rssFeedParser = new FeedParser();
             RssFeed feed = await rssFeedParser.ParseFeed(doc);
 
-            Assert.Equal(feed.Articles.Count, 99);
+            Assert.Equal(99, feed.Articles.Count);
 
             foreach (var article in feed.Articles)
-            {
                 Assert.False(string.IsNullOrEmpty(article.Image));
-
-            }
-
         }
 
         [Fact]
@@ -107,20 +101,19 @@ namespace RssFeedParser.Test
             var rssFeedParser = new FeedParser();
             RssFeed feed = await rssFeedParser.ParseFeed(doc);
 
-            Assert.Equal(feed.Articles.Count, 235);
+            Assert.Equal(235, feed.Articles.Count);
         }
 
         [Fact]
         public void FeedParserShouldParseArticles()
         {
+            //var feed = "http://feeds.feedburner.com/ChefSteps";
 
-            var feed = "http://feeds.feedburner.com/ChefSteps";
-
-            var rssFeedParser = new FeedParser();
-            var articles = rssFeedParser.ParseFeed(feed);
+            //var rssFeedParser = new FeedParser();
+            //var articles = rssFeedParser.ParseFeed(feed);
 
 
-            string feedUrl = "http://uk.businessinsider.com/rss";
+            //string feedUrl = "http://uk.businessinsider.com/rss";
             //  string feedUrl = "http://coffeegeek.com/rss";
 
             //var parser = new FeedParser();

--- a/RssFeedParser.Test/FeedParserTest.cs
+++ b/RssFeedParser.Test/FeedParserTest.cs
@@ -25,7 +25,7 @@ namespace RssFeedParser.Test
             var rssFeedParser = new FeedParser();
             RssFeed feed = await rssFeedParser.ParseFeed(doc);
 
-            Assert.Equal(feed.Articles.Count, 30);
+            Assert.Equal(30, feed.Articles.Count);
 
             foreach (var article in feed.Articles)
             {
@@ -36,6 +36,7 @@ namespace RssFeedParser.Test
             }
 
         }
+
         [Fact]
         public async void TestTweakersFeed()
         {

--- a/RssFeedParser.Test/RssFeedParser.Test.csproj
+++ b/RssFeedParser.Test/RssFeedParser.Test.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFramework>netcoreapp2.0</TargetFramework>
+        <TargetFramework>net5.0</TargetFramework>
     </PropertyGroup>
 
     <ItemGroup>
@@ -15,10 +15,13 @@
     </ItemGroup>
 
     <ItemGroup>
-        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.0.0" />
-        <PackageReference Include="xunit.runner.visualstudio" Version="2.2.0" />
-        <PackageReference Include="Moq" Version="4.7.9" />
-        <PackageReference Include="xunit" Version="2.2.0" />
+        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.10.0" />
+        <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">
+          <PrivateAssets>all</PrivateAssets>
+          <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+        </PackageReference>
+        <PackageReference Include="Moq" Version="4.16.1" />
+        <PackageReference Include="xunit" Version="2.4.1" />
         <PackageReference Include="System.Xml.XmlDocument" Version="4.3.0" />
 
     </ItemGroup>

--- a/RssFeedParser/FeedParser.cs
+++ b/RssFeedParser/FeedParser.cs
@@ -16,11 +16,9 @@ namespace RssFeedParser
 
         public async Task<RssFeed> ParseFeed(string url)
         {
-            using (HttpClient client = new HttpClient())
-            {
-                Stream stream = await client.GetStreamAsync(url);
-                return await ParseFeed(XDocument.Load(stream));
-            }
+            using HttpClient client = new HttpClient();
+            Stream stream = await client.GetStreamAsync(url);
+            return await ParseFeed(XDocument.Load(stream));
         }
 
         public async Task<RssFeed> ParseFeed(XDocument doc)
@@ -30,42 +28,30 @@ namespace RssFeedParser
 
             XElement root = doc.Root;
 
-            if (type == FeedTypes.RSS)
+            if (type is FeedTypes.RSS)
             {
                 var items = root.Element("channel").Elements("item");
 
                 if (items != null)
-                {
                     foreach (XElement item in items)
-                    {
                         outputFeed.Articles.Add(ParseRSSArticle(item));
-                    }
-                }
             }
             else
             {
                 var items = doc.Elements().First().Elements().Where(e => e.Name.LocalName == "entry");
 
                 if (items != null)
-                {
                     foreach (XElement item in items)
-                    {
                         outputFeed.Articles.Add(ParseAtomArticle(item));
-                    }
-                }
             }
 
             try
             {
 
-                using (var client = new HttpClient())
-                {
+                using var client = new HttpClient();
 
-                    foreach (var article in outputFeed.Articles.Where(x => string.IsNullOrEmpty(x.Image)))
-                    {
-                        article.Image = await UseOgTagForArticleImage(client, article);
-                    }
-                }
+                foreach (var article in outputFeed.Articles.Where(x => string.IsNullOrEmpty(x.Image)))
+                    article.Image = await UseOgTagForArticleImage(client, article);
             }
             catch (Exception)
             {
@@ -78,7 +64,6 @@ namespace RssFeedParser
 
         private async Task<string> UseOgTagForArticleImage(HttpClient client, RssFeedArticle article)
         {
-
             var articleResponse = await client.GetAsync(article.Link);
             var html = await articleResponse.Content.ReadAsStringAsync();
 
@@ -95,29 +80,14 @@ namespace RssFeedParser
             if (string.IsNullOrWhiteSpace(ogImageContentTag)) return string.Empty;
 
             // If not a valid url just return null
-            Uri mediaUrl;
-            if (!Uri.TryCreate(ogImageContentTag, UriKind.RelativeOrAbsolute, out mediaUrl))
-            {
-                return string.Empty;
-            }
-
-            return mediaUrl.ToString();
-
+            return !Uri.TryCreate(ogImageContentTag, UriKind.RelativeOrAbsolute, out Uri mediaUrl) ? string.Empty : mediaUrl.ToString();
         }
 
         private FeedTypes DetermineFeedType(XDocument doc)
         {
             XElement root = doc.Root;
 
-            if (root.Element("channel") != null)
-            {
-                return FeedTypes.RSS;
-            }
-            else
-            {
-                return FeedTypes.Atom;
-            }
-
+            return root.Element("channel") != null ? FeedTypes.RSS : FeedTypes.Atom;
         }
 
         private RssFeedArticle ParseRSSArticle(XElement item)
@@ -125,50 +95,33 @@ namespace RssFeedParser
             var newArticle = new RssFeedArticle();
 
             if (item.Element("title") != null)
-            {
                 newArticle.Title = item.Element("title").Value;
-            }
 
             XNamespace dc = "http://search.yahoo.com/mrss/";
 
             if (item.Element(dc + "thumbnail") != null && item.Element(dc + "thumbnail").Attribute("url") != null)
-            {
                 newArticle.Image = item.Element(dc + "thumbnail").Attribute("url").Value;
-            }
 
             if (item.Element("description") != null)
             {
-
                 newArticle.Content = item.Element("description").Value;
 
                 if (string.IsNullOrEmpty(newArticle.Image))
-                {
                     newArticle.Image = FindThumbnailForArticle(newArticle.Content);
-                }
-
             }
 
             if (item.Element("link") != null)
-            {
                 newArticle.Link = item.Element("link").Value;
-            }
 
             if (item.Element("pubDate") != null)
-            {
                 newArticle.Published = ParsePublishedDate(item.Element("pubDate").Value);
-            }
 
             if (item.Elements("category") != null)
-            {
                 foreach (var cat in item.Elements("category"))
-                {
                     newArticle.Categories.Add(new RssFeedArticleCategory()
                     {
                         Name = cat.Value.ToLower()
                     });
-                }
-
-            }
 
             return newArticle;
         }
@@ -180,9 +133,7 @@ namespace RssFeedParser
             var elements = item.Elements();
 
             if (elements.First(i => i.Name.LocalName == "title") != null)
-            {
-                newArticle.Title = item.Elements().First(i => i.Name.LocalName == "title").Value;
-            }
+            newArticle.Title = item.Elements().First(i => i.Name.LocalName == "title").Value;
 
             if (elements.FirstOrDefault(i => i.Name != null && i.Name.LocalName == "content") != null)
             {
@@ -191,22 +142,15 @@ namespace RssFeedParser
             }
 
             if (elements.FirstOrDefault(i => i.Name.LocalName == "link") != null && item.Elements().First(i => i.Name.LocalName == "link").Attribute("href") != null)
-            {
                 newArticle.Link = item.Elements().First(i => i.Name.LocalName == "link").Attribute("href").Value;
-            }
 
             if (elements.FirstOrDefault(i => i.Name.LocalName == "published") != null)
-            {
                 newArticle.Published = ParsePublishedDate(item.Elements().First(i => i.Name.LocalName == "published").Value);
-            }
 
             return newArticle;
         }
 
-        private DateTime ParsePublishedDate(string dateString)
-        {
-            return DateTime.Parse(dateString);
-        }
+        private DateTime ParsePublishedDate(string dateString) => DateTime.Parse(dateString);
 
         private string FindThumbnailForArticle(string description)
         {
@@ -215,16 +159,7 @@ namespace RssFeedParser
 
             var imageUrl = match.Value;
 
-            if (Path.HasExtension(imageUrl))
-            {
-                return imageUrl;
-            }
-            else
-            {
-                return string.Empty;
-            }
-
+            return Path.HasExtension(imageUrl) ? imageUrl : string.Empty;
         }
-
     }
 }

--- a/RssFeedParser/Models/RssFeedArticle.cs
+++ b/RssFeedParser/Models/RssFeedArticle.cs
@@ -17,6 +17,5 @@ namespace RssFeedParser.Models
         public string Image { get; set; }
         public DateTime Published { get; set; }
         public List<RssFeedArticleCategory> Categories { get; set; }
-
     }
 }

--- a/RssFeedParser/RssFeedParser.csproj
+++ b/RssFeedParser/RssFeedParser.csproj
@@ -1,12 +1,12 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFramework>netstandard2.0</TargetFramework>
+        <TargetFramework>netstandard2.1</TargetFramework>
         <Version>1.0.4</Version>
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="HtmlAgilityPack.NetCore" Version="1.5.0.1" />
+      <PackageReference Include="HtmlAgilityPack" Version="1.11.35" />
     </ItemGroup>
 
 </Project>

--- a/RssFeedParser/RssFeedParser.csproj
+++ b/RssFeedParser/RssFeedParser.csproj
@@ -1,8 +1,8 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
         <TargetFramework>netstandard2.1</TargetFramework>
-        <Version>1.0.4</Version>
+        <Version>1.1.0</Version>
     </PropertyGroup>
 
     <ItemGroup>

--- a/RssFeedParser/RssFeedParser.csproj
+++ b/RssFeedParser/RssFeedParser.csproj
@@ -3,6 +3,13 @@
     <PropertyGroup>
         <TargetFramework>netstandard2.1</TargetFramework>
         <Version>1.1.0</Version>
+        <Authors>mhtsbt, DiegoG1014</Authors>
+        <Description>A simple parser for RSS Feeds</Description>
+        <Company>Open Source</Company>
+        <PackageProjectUrl>https://github.com/mhtsbt/RssFeedParser</PackageProjectUrl>
+        <RepositoryUrl>https://github.com/mhtsbt/RssFeedParser</RepositoryUrl>
+        <RepositoryType>Git</RepositoryType>
+        <PackageTags>Rss, Feed, RssFeed, Atom, AtomFeed</PackageTags>
     </PropertyGroup>
 
     <ItemGroup>


### PR DESCRIPTION
Updated both RssFeedParser and RssFeedParser.Test's dependencies to the latest stable versions, replacing deprecated packages

Updated RssFeedParser target to netstandard2.1
Updated RssFeedParser.Test target to net5.0